### PR TITLE
Add diagnostics functionality through Plant UML jar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ config = function()
                 cmd = {
                     "/path/to/plantuml_lsp",
                     "--stdlib-path=/path/to/plantuml-stdlib",
-                    "--jar-path=/path/to/plantuml-jar",
+                    "--exec-path='java -jar /path/to/plantuml.jar'",
+                    -- With plantuml executable and available from your PATH there is a simpler method:
+                    -- "--exec-path=plantuml"
                 },
                 filetypes = { "plantuml" },
                 root_dir = function(fname)
@@ -54,7 +56,9 @@ end,
 ```
 
 * NOTE: This assumes plantuml is set up as a filetype already
-* NOTE: cmd flag `--jar-path` is used to derive diagnostics. The flag can optionally be omitted
+* NOTE: cmd flag `--exec-path` is used to derive diagnostics. The flag can optionally be omitted
+    * This argument allows for use of plantuml via a Jar or a system visible binary.
+
 
 ---
 
@@ -95,7 +99,7 @@ TODO (I don't use VS Code)
 - [ ] User Defined (Backlog)
 
 #### Diagnostics
-- Diagnostics currently depend on `Plant UML jar -syntax` output
+- Diagnostics currently depend on `plantuml -syntax` output
 - [x] Core
 - [x] stdlib/C4
 - [x] Other stdlib

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ config = function()
     if not configs.plantuml_lsp then
         configs.plantuml_lsp = {
             default_config = {
-                cmd = { "/path/to/plantuml_lsp", "--stdlib-path=/path/to/plantuml-stdlib" },
+                cmd = {
+                    "/path/to/plantuml_lsp",
+                    "--stdlib-path=/path/to/plantuml-stdlib",
+                    "--jar-path=/path/to/plantuml-jar",
+                },
                 filetypes = { "plantuml" },
                 root_dir = function(fname)
                     return lspconfig.util.find_git_ancestor(fname) or lspconfig.util.path.dirname(fname)
@@ -50,6 +54,7 @@ end,
 ```
 
 * NOTE: This assumes plantuml is set up as a filetype already
+* NOTE: cmd flag `--jar-path` is used to derive diagnostics. The flag can optionally be omitted
 
 ---
 
@@ -90,9 +95,10 @@ TODO (I don't use VS Code)
 - [ ] User Defined (Backlog)
 
 #### Diagnostics
-- [ ] Core (Backlog)
-- [ ] stdlib/C4 (Backlog)
-- [ ] Other stdlib (Backlog)
+- Diagnostics currently depend on `Plant UML jar -syntax` output
+- [x] Core
+- [x] stdlib/C4
+- [x] Other stdlib
 - [ ] User Defined (Backlog)
 
 #### Other Language Server Features

--- a/analysis/diagnostics.go
+++ b/analysis/diagnostics.go
@@ -1,22 +1,49 @@
 package analysis
 
-import "plantuml_lsp/lsp"
+import (
+	"bytes"
+	"os/exec"
+	"plantuml_lsp/lsp"
+	"strconv"
+	"strings"
+)
 
-// TODO: actual diagnostics
-func getDiagnosticsForFile(text string) []lsp.Diagnostic {
-	diagnostics := []lsp.Diagnostic{}
-	_ = text
-	// for row, line := range strings.Split(text, "\n") {
-	// 	if strings.Contains(line, "text") {
-	// 		idx := strings.Index(line, "text")
-	// 		diagnostics = append(diagnostics, lsp.Diagnostic{
-	// 			Range:    lineRange(row, idx, idx+len("text")),
-	// 			Severity: 2,
-	// 			Source:   "plantuml-lsp",
-	// 			Message:  "message",
-	// 		})
-	// 	}
-	// }
+func getDiagnosticsForFile(text string, plantUmlJarPath string) []lsp.Diagnostic {
+	if len(plantUmlJarPath) == 0 {
+		return []lsp.Diagnostic{}
+	}
+	plantUmlDiagnostics := getPlantUmlDiagnostics(text, plantUmlJarPath)
+	splitText := strings.Split(text, "\n")
+	return parsePlantUmlDiagnostics(plantUmlDiagnostics, splitText)
+}
 
-	return diagnostics
+func getPlantUmlDiagnostics(text string, plantUmlJarPath string) string {
+	plantumlCmd := exec.Command("java", "-jar", plantUmlJarPath, "-syntax")
+	plantumlCmd.Stdin = bytes.NewReader([]byte(text))
+	output, _ := plantumlCmd.CombinedOutput()
+	return string(output)
+}
+
+func parsePlantUmlDiagnostics(plantUmlDiagnostics string, text []string) []lsp.Diagnostic {
+	diagnosticsStrings := strings.Split(plantUmlDiagnostics, "\n")
+	if len(diagnosticsStrings) < 3 || diagnosticsStrings[0] != "ERROR" {
+		return []lsp.Diagnostic{}
+	}
+
+	lineNumber, err := strconv.Atoi(diagnosticsStrings[1])
+	if err != nil {
+		//TODO: propagate diagnostics parse failure to logger(s)
+		return []lsp.Diagnostic{}
+	}
+
+	lineLength := len(text[lineNumber])
+
+	parsedDiagnostics := []lsp.Diagnostic{}
+	parsedDiagnostics = append(parsedDiagnostics, lsp.Diagnostic{
+		Range:    lineRange(lineNumber, 0, lineLength),
+		Severity: 1,
+		Source:   "plantuml-lsp",
+		Message:  diagnosticsStrings[2],
+	})
+	return parsedDiagnostics
 }

--- a/analysis/diagnostics.go
+++ b/analysis/diagnostics.go
@@ -8,17 +8,18 @@ import (
 	"strings"
 )
 
-func getDiagnosticsForFile(text string, plantUmlJarPath string) []lsp.Diagnostic {
-	if len(plantUmlJarPath) == 0 {
+func getDiagnosticsForFile(text string, plantUmlExecPath []string) []lsp.Diagnostic {
+	if len(plantUmlExecPath) == 0 {
 		return []lsp.Diagnostic{}
 	}
-	plantUmlDiagnostics := getPlantUmlDiagnostics(text, plantUmlJarPath)
+	plantUmlDiagnostics := getPlantUmlDiagnostics(text, plantUmlExecPath)
 	splitText := strings.Split(text, "\n")
 	return parsePlantUmlDiagnostics(plantUmlDiagnostics, splitText)
 }
 
-func getPlantUmlDiagnostics(text string, plantUmlJarPath string) string {
-	plantumlCmd := exec.Command("java", "-jar", plantUmlJarPath, "-syntax")
+func getPlantUmlDiagnostics(text string, plantUmlExecPath []string) string {
+	plantUmlExecPath = append(plantUmlExecPath, "-syntax")
+	plantumlCmd := exec.Command(plantUmlExecPath[0], plantUmlExecPath[1:]...)
 	plantumlCmd.Stdin = bytes.NewReader([]byte(text))
 	output, _ := plantumlCmd.CombinedOutput()
 	return string(output)

--- a/analysis/state.go
+++ b/analysis/state.go
@@ -1,7 +1,7 @@
 package analysis
 
 import (
-	"plantuml_lsp/features"
+	completion "plantuml_lsp/features"
 	"plantuml_lsp/lsp"
 )
 
@@ -21,16 +21,16 @@ func NewState() State {
 	return State{Documents: map[string]string{}}
 }
 
-func (s *State) OpenDocument(uri, text string, jarPath string) []lsp.Diagnostic {
+func (s *State) OpenDocument(uri, text string, execPath []string) []lsp.Diagnostic {
 	s.Documents[uri] = text
 
-	return getDiagnosticsForFile(text, jarPath)
+	return getDiagnosticsForFile(text, execPath)
 }
 
-func (s *State) UpdateDocument(uri, text string, jarPath string) []lsp.Diagnostic {
+func (s *State) UpdateDocument(uri, text string, execPath []string) []lsp.Diagnostic {
 	s.Documents[uri] = text
 
-	return getDiagnosticsForFile(text, jarPath)
+	return getDiagnosticsForFile(text, execPath)
 }
 
 // TODO: param options?

--- a/analysis/state.go
+++ b/analysis/state.go
@@ -21,16 +21,16 @@ func NewState() State {
 	return State{Documents: map[string]string{}}
 }
 
-func (s *State) OpenDocument(uri, text string) []lsp.Diagnostic {
+func (s *State) OpenDocument(uri, text string, jarPath string) []lsp.Diagnostic {
 	s.Documents[uri] = text
 
-	return getDiagnosticsForFile(text)
+	return getDiagnosticsForFile(text, jarPath)
 }
 
-func (s *State) UpdateDocument(uri, text string) []lsp.Diagnostic {
+func (s *State) UpdateDocument(uri, text string, jarPath string) []lsp.Diagnostic {
 	s.Documents[uri] = text
 
-	return getDiagnosticsForFile(text)
+	return getDiagnosticsForFile(text, jarPath)
 }
 
 // TODO: param options?

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FIX: logging to lsp log not working
-func HandleMessage(writer io.Writer, state analysis.State, method string, contents []byte, stdlibPath string, jarPath string) {
+func HandleMessage(writer io.Writer, state analysis.State, method string, contents []byte, stdlibPath string, execPath []string) {
 	SendLogMessage(writer, "Received msg with method: "+method, lsp.Debug)
 
 	switch method {
@@ -39,7 +39,7 @@ func HandleMessage(writer io.Writer, state analysis.State, method string, conten
 		}
 
 		SendLogMessage(writer, "Opened: "+request.Params.TextDocument.URI, lsp.Debug)
-		diagnostics := state.OpenDocument(request.Params.TextDocument.URI, request.Params.TextDocument.Text, jarPath)
+		diagnostics := state.OpenDocument(request.Params.TextDocument.URI, request.Params.TextDocument.Text, execPath)
 		writeResponse(writer, lsp.PublishDiagnosticsNotification{
 			Notification: lsp.Notification{
 				RPC:    "2.0",
@@ -60,7 +60,7 @@ func HandleMessage(writer io.Writer, state analysis.State, method string, conten
 
 		SendLogMessage(writer, "Changed: "+request.Params.TextDocument.URI, lsp.Debug)
 		for _, change := range request.Params.ContentChanges {
-			diagnostics := state.UpdateDocument(request.Params.TextDocument.URI, change.Text, jarPath)
+			diagnostics := state.UpdateDocument(request.Params.TextDocument.URI, change.Text, execPath)
 			writeResponse(writer, lsp.PublishDiagnosticsNotification{
 				Notification: lsp.Notification{
 					RPC:    "2.0",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FIX: logging to lsp log not working
-func HandleMessage(writer io.Writer, state analysis.State, method string, contents []byte, stdlibPath string) {
+func HandleMessage(writer io.Writer, state analysis.State, method string, contents []byte, stdlibPath string, jarPath string) {
 	SendLogMessage(writer, "Received msg with method: "+method, lsp.Debug)
 
 	switch method {
@@ -39,7 +39,7 @@ func HandleMessage(writer io.Writer, state analysis.State, method string, conten
 		}
 
 		SendLogMessage(writer, "Opened: "+request.Params.TextDocument.URI, lsp.Debug)
-		diagnostics := state.OpenDocument(request.Params.TextDocument.URI, request.Params.TextDocument.Text)
+		diagnostics := state.OpenDocument(request.Params.TextDocument.URI, request.Params.TextDocument.Text, jarPath)
 		writeResponse(writer, lsp.PublishDiagnosticsNotification{
 			Notification: lsp.Notification{
 				RPC:    "2.0",
@@ -60,7 +60,7 @@ func HandleMessage(writer io.Writer, state analysis.State, method string, conten
 
 		SendLogMessage(writer, "Changed: "+request.Params.TextDocument.URI, lsp.Debug)
 		for _, change := range request.Params.ContentChanges {
-			diagnostics := state.UpdateDocument(request.Params.TextDocument.URI, change.Text)
+			diagnostics := state.UpdateDocument(request.Params.TextDocument.URI, change.Text, jarPath)
 			writeResponse(writer, lsp.PublishDiagnosticsNotification{
 				Notification: lsp.Notification{
 					RPC:    "2.0",

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"plantuml_lsp/analysis"
@@ -17,10 +18,18 @@ func main() {
 
 	logPath := flag.String("log-path", "", "LSP log path")
 	stdlibPath := flag.String("stdlib-path", "", "PlantUML stdlib path")
+	jarPath := flag.String("jar-path", "", "PlantUML jar path")
 	flag.Parse()
 
 	logger := getLogger(*logPath)
 	logger.Println("Started plantuml-lsp")
+
+	if len(*jarPath) != 0 {
+		if _, err := os.Stat(*jarPath); err != nil {
+			logger.Println(fmt.Sprintf("Error during 'os.Stat(*jarPath)' for *jarPath: '%s'", *jarPath))
+			panic(err)
+		}
+	}
 
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Split(rpc.Split)
@@ -36,7 +45,7 @@ func main() {
 			continue
 		}
 
-		handler.HandleMessage(writer, state, method, contents, *stdlibPath)
+		handler.HandleMessage(writer, state, method, contents, *stdlibPath, *jarPath)
 	}
 }
 


### PR DESCRIPTION
Added primitive error diagnostics support through Plant UML's -syntax command.

This adds a generic error message on the first containing an error. If a file contains more errors, only the first one is highlighted due to the way the Plant UML command works. Benefits are that the error diagnostic should always correspond with the Plant UML version used by the user to generate diagrams, as the same jar file is utilized (hopefully). 

Not sure if this implementation aligns with this project's philosophy/goal as this seems to be the dirty/quick solution regarding diagnostics, as opposed to implementing a novel token parser.

I was also unsure how to test user defined syntax.