### PR TITLE
Fix package imports in tests

### DIFF
--- a/internal/parse/parse_c4_test.go
+++ b/internal/parse/parse_c4_test.go
@@ -4,7 +4,7 @@ import (
 	// "fmt"
 	// "log"
 	// "os"
-	"plantuml_lsp/parse"
+	"github.com/ptdewey/plantuml-lsp/internal/parse"
 	"reflect"
 	"testing"
 )

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -1,7 +1,7 @@
 package rpc_test
 
 import (
-	"plantuml_lsp/rpc"
+	"github.com/ptdewey/plantuml-lsp/internal/rpc"
 	"testing"
 )
 


### PR DESCRIPTION
`go test ./...` was failing due to incorrect package imports:

```
$ go test ./...
(main)
internal/parse/parse_c4_test.go:7:2: package plantuml_lsp/parse is not in std (<REMOVED>/golang/1.22.3/go/src/plantuml_lsp/parse)
FAIL    github.com/ptdewey/plantuml-lsp/internal/parse [setup failed]
internal/rpc/rpc_test.go:4:2: package plantuml_lsp/rpc is not in std (<REMOVED>/golang/1.22.3/go/src/plantuml_lsp/rpc)
FAIL    github.com/ptdewey/plantuml-lsp/internal/rpc [setup failed]
?       github.com/ptdewey/plantuml-lsp [no test files]
?       github.com/ptdewey/plantuml-lsp/internal/analysis       [no test files]
?       github.com/ptdewey/plantuml-lsp/internal/features       [no test files]
?       github.com/ptdewey/plantuml-lsp/internal/language       [no test files]
?       github.com/ptdewey/plantuml-lsp/internal/lsp    [no test files]
ok      github.com/ptdewey/plantuml-lsp/internal/handler        0.385s
FAIL
```

Seems like tests for `internal/parse` and `internal/rpc` package haven't been updated properly after one of recent refactorings.

All tests pass now.

---

Thank you for review and constructive feedback! 🍰 