### PR TITLE
Add missing tests for `internal/rpc` package

### DIFF
--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -1,38 +1,198 @@
 package rpc_test
 
 import (
-	"github.com/ptdewey/plantuml-lsp/internal/rpc"
+	"bytes"
+	"errors"
 	"testing"
+
+	"github.com/ptdewey/plantuml-lsp/internal/rpc"
 )
 
 type EncodingExample struct {
 	Testing bool
 }
 
-func TestEncode(t *testing.T) {
-	expected := "Content-Length: 16\r\n\r\n{\"Testing\":true}"
-	actual, err := rpc.EncodeMessage(EncodingExample{Testing: true})
-	if err != nil {
-		t.Fatal(err)
+// FailingEncodingExample is designed to fail JSON encoding.
+// It's intended to use in test cases where it's necessary to simulate a JSON encoding error.
+type FailingEncodingExample struct{}
+
+func (e FailingEncodingExample) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("intentional error")
+}
+
+func TestEncodeMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  any
+		want string
+		err  error
+	}{
+		{
+			name: "message",
+			msg:  EncodingExample{Testing: true},
+			want: "Content-Length: 16\r\n\r\n{\"Testing\":true}",
+			err:  nil,
+		},
+		{
+			name: "message with marshaling error",
+			msg:  FailingEncodingExample{},
+			want: "",
+			err:  errors.New("json: error calling MarshalJSON for type rpc_test.FailingEncodingExample: intentional error"),
+		},
 	}
-	if expected != actual {
-		t.Fatalf("Expected: %s, Actual: %s", expected, actual)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := rpc.EncodeMessage(tt.msg)
+			if !equalErrors(t, err, tt.err) {
+				t.Fatalf("Unexpected error:\n\tgot:  %v\n\twant: %v", err, tt.err)
+			}
+
+			if got != tt.want {
+				t.Errorf("Invalid message encoding:\n\tgot:  %s\n\twant: %s", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestDecode(t *testing.T) {
-	incomingMessage := "Content-Length: 15\r\n\r\n{\"Method\":\"hi\"}"
-	method, content, err := rpc.DecodeMessage([]byte(incomingMessage))
-	contentLength := len(content)
-	if err != nil {
-		t.Fatal(err)
+func TestDecodeMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     []byte
+		method  string
+		content []byte
+		err     error
+	}{
+		{
+			name:    "message",
+			msg:     []byte("Content-Length: 15\r\n\r\n{\"Method\":\"hi\"}"),
+			method:  "hi",
+			content: []byte("{\"Method\":\"hi\"}"),
+			err:     nil,
+		},
+		{
+			name:    "message without separator",
+			msg:     []byte("Content-Length: 15 {\"Method\":\"hi\"}"),
+			method:  "",
+			content: nil,
+			err:     errors.New("Separator not found"),
+		},
+		{
+			name:    "message with invalid separator",
+			msg:     []byte("Content-Length: 15\r\n{\"Method\":\"hi\"}"),
+			method:  "",
+			content: nil,
+			err:     errors.New("Separator not found"),
+		},
+		{
+			name:    "message with invalid content length",
+			msg:     []byte("Content-Length: --\r\n\r\n{\"Method\":\"hi\"}"),
+			method:  "",
+			content: nil,
+			err:     errors.New("strconv.Atoi: parsing \"--\": invalid syntax"),
+		},
+		{
+			name:    "message with invalid JSON",
+			msg:     []byte("Content-Length: 15\r\n\r\n{\"Method\":\"hi\"x_x"),
+			method:  "",
+			content: nil,
+			err:     errors.New("invalid character 'x' after object key:value pair"),
+		},
 	}
 
-	if contentLength != 15 {
-		t.Fatalf("Expected: 16, Got: %d", contentLength)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			method, content, err := rpc.DecodeMessage(tt.msg)
+			if !equalErrors(t, err, tt.err) {
+				t.Fatalf("Unexpected error:\n\tgot:  %v\n\twant: %v", err, tt.err)
+			}
+
+			if method != tt.method {
+				t.Errorf("Invalid method decoding:\n\tgot:  %s\n\twant: %s", method, tt.method)
+			}
+
+			if !bytes.Equal(content, tt.content) {
+				t.Errorf("Invalid content decoding:\n\tgot:  %s\n\twant: %s", content, tt.content)
+			}
+		})
+	}
+}
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		atEOF   bool
+		length  int
+		content []byte
+		err     error
+	}{
+		{
+			name:    "message",
+			data:    []byte("Content-Length: 15\r\n\r\n{\"Method\":\"hi\"}"),
+			atEOF:   false,
+			length:  37,
+			content: []byte("Content-Length: 15\r\n\r\n{\"Method\":\"hi\"}"),
+			err:     nil,
+		},
+		{
+			name:    "message without separator",
+			data:    []byte("Content-Length: 15 {\"Method\":\"hi\"}"),
+			atEOF:   false,
+			length:  0,
+			content: nil,
+			err:     errors.New("Separator not found"),
+		},
+		{
+			name:    "message with invalid separator",
+			data:    []byte("Content-Length: 15\r\n{\"Method\":\"hi\"}"),
+			atEOF:   false,
+			length:  0,
+			content: nil,
+			err:     errors.New("Separator not found"),
+		},
+		{
+			name:    "message with invalid content length",
+			data:    []byte("Content-Length: --\r\n\r\n{\"Method\":\"hi\"}"),
+			atEOF:   false,
+			length:  0,
+			content: nil,
+			err:     errors.New("strconv.Atoi: parsing \"--\": invalid syntax"),
+		},
+		{
+			name:    "message with incorrect content length",
+			data:    []byte("Content-Length: 100\r\n\r\n{\"Method\":\"hi\"}"),
+			atEOF:   false,
+			length:  0,
+			content: nil,
+			err:     nil,
+		},
 	}
 
-	if method != "hi" {
-		t.Fatalf("Expected: 'hi', Got: %s", method)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			length, content, err := rpc.Split(tt.data, tt.atEOF)
+			if !equalErrors(t, err, tt.err) {
+				t.Fatalf("Unexpected error:\n\tgot:  %v\n\twant: %v", err, tt.err)
+			}
+
+			if length != tt.length {
+				t.Errorf("Invalid length:\n\tgot:  %d\n\twant: %d", length, tt.length)
+			}
+
+			if !bytes.Equal(content, tt.content) {
+				t.Errorf("Invalid content:\n\tgot:  %s\n\twant: %s", content, tt.content)
+			}
+		})
 	}
+}
+
+func equalErrors(t testing.TB, a, b error) bool {
+	t.Helper()
+
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+
+	return a.Error() == b.Error()
 }


### PR DESCRIPTION
- Changed test method naming to follow a common pattern `Test<MethodName>`
- Added new test cases for encoding and decoding methods
- Added completely missing tests for `rpc.Split`

```
go test github.com/ptdewey/plantuml-lsp/internal/rpc -v -cover
=== RUN   TestEncodeMessage
=== RUN   TestEncodeMessage/message
=== RUN   TestEncodeMessage/message_with_marshaling_error
--- PASS: TestEncodeMessage (0.00s)
    --- PASS: TestEncodeMessage/message (0.00s)
    --- PASS: TestEncodeMessage/message_with_marshaling_error (0.00s)
=== RUN   TestDecodeMessage
=== RUN   TestDecodeMessage/message
=== RUN   TestDecodeMessage/message_without_separator
=== RUN   TestDecodeMessage/message_with_invalid_separator
=== RUN   TestDecodeMessage/message_with_invalid_content_length
=== RUN   TestDecodeMessage/message_with_invalid_JSON
--- PASS: TestDecodeMessage (0.00s)
    --- PASS: TestDecodeMessage/message (0.00s)
    --- PASS: TestDecodeMessage/message_without_separator (0.00s)
    --- PASS: TestDecodeMessage/message_with_invalid_separator (0.00s)
    --- PASS: TestDecodeMessage/message_with_invalid_content_length (0.00s)
    --- PASS: TestDecodeMessage/message_with_invalid_JSON (0.00s)
=== RUN   TestSplit
=== RUN   TestSplit/message
=== RUN   TestSplit/message_without_separator
=== RUN   TestSplit/message_with_invalid_separator
=== RUN   TestSplit/message_with_invalid_content_length
=== RUN   TestSplit/message_with_incorrect_content_length
--- PASS: TestSplit (0.00s)
    --- PASS: TestSplit/message (0.00s)
    --- PASS: TestSplit/message_without_separator (0.00s)
    --- PASS: TestSplit/message_with_invalid_separator (0.00s)
    --- PASS: TestSplit/message_with_invalid_content_length (0.00s)
    --- PASS: TestSplit/message_with_incorrect_content_length (0.00s)
PASS
coverage: 100.0% of statements
ok      github.com/ptdewey/plantuml-lsp/internal/rpc    (cached)        coverage: 100.0% of statements
```

Test coverage for `internal/rpc` package is 100%.

NOTE: `internal/rpc` package might have some refactoring applied. For example `rpc.DecodeMessage` and `rpc.Split` share common functionality that could be extracted. However it would make sense to make such changes when test coverage is sufficient.