### PR TITLE
Change Go version detection in the test workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22.3'
+        go-version-file: go.mod
 
     - name: Run Tests
       run: go test -v ./...


### PR DESCRIPTION
The `actions/setup-go` action has [ability to detect Go version from `go.mod` file][1]. In that case `go-version-file` input needs to be used instead of `go-version`.

As long as there's no need in multiple Go versions (like with the matrix testing) or the SemVer range syntax (like `>=1.17.0`), `go-version-file` input might be a better choice because it makes `go.mod` file a single source of truth and simplifies maintenance.

Example:

<img width="1450" alt="Screenshot 2025-04-11 at 08 01 54" src="https://github.com/user-attachments/assets/eca8f880-c2d3-450c-8a4e-2cca20536065" />

The currently used [Go version](https://github.com/ptdewey/plantuml-lsp/blob/90a3e26ef054ecba184713c9c4f6d5b2ba8ade77/go.mod#L3) is correctly detected for this pull request from `go.mod` file.

---

Thank you for review and constructive feedback! 🍰 

[1]: https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file