### PR TITLE
Update `actions/setup-go` to v5

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22.3'
 


### PR DESCRIPTION
The `actions/setup-go` action has [the v5 edition][1] already.

---

Thank you for review and constructive feedback! 🍰 

[1]: https://github.com/actions/setup-go?tab=readme-ov-file#v5