### PR TITLE
Update `actions/checkout` to v4

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
The latest version branch for `actions/checkout` is [v4][1].

---

Thank you for review and constructive feedback! 🍰 

[1]: https://github.com/actions/checkout/releases/tag/v4.2.2