### PR TITLE
Fix communication issue with Sublime Text

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -18,14 +17,10 @@ func main() {
 	// TODO: pass in plantuml_lsp.rc file to use for config stuff
 	// - include log level https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage
 
-	logPath := flag.String("log-path", "", "LSP log path")
 	stdlibPath := flag.String("stdlib-path", "", "PlantUML stdlib path")
 	execCmd := flag.String("exec-path", "", "PlantUML executable command")
 	jarPath := flag.String("jar-path", "", "PlantUML jar path")
 	flag.Parse()
-
-	logger := getLogger(*logPath)
-	logger.Println("Started plantuml-lsp")
 
 	var plantumlCmd []string
 	if len(*execCmd) > 0 {
@@ -48,6 +43,8 @@ func main() {
 	state := analysis.NewState()
 	writer := os.Stdout
 
+	handler.SendLogMessage(writer, "Started plantuml-lsp", lsp.Debug)
+
 	for scanner.Scan() {
 		msg := scanner.Bytes()
 		method, contents, err := rpc.DecodeMessage(msg)
@@ -58,17 +55,4 @@ func main() {
 
 		handler.HandleMessage(writer, state, method, contents, *stdlibPath, plantumlCmd)
 	}
-}
-
-func getLogger(filename string) *log.Logger {
-	if filename == "" {
-		return log.New(os.Stdout, "[plantuml-lsp]", log.Ldate|log.Ltime|log.Lshortfile)
-	}
-
-	logfile, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-	if err != nil {
-		panic(err)
-	}
-
-	return log.New(logfile, "[plantuml-lsp]", log.Ldate|log.Ltime|log.Lshortfile)
 }


### PR DESCRIPTION
The LSP client of Sublime Text doesn't like the output from an LSP server when it contains something that isn't following the LSP protocol. It throws an error and stops trying to connect.

<img width="1109" alt="Screenshot 2025-04-12 at 13 15 47" src="https://github.com/user-attachments/assets/5ee4b575-875c-47b3-a9c5-e29d4c1bd839" />

To fix the issue, the logline that wasn't following the LSP protocol was replaced with a `window/logMessage` notification. That allows to still have the message in the output and doesn't break the Sublime LSP client at the same time.

<img width="1220" alt="Screenshot 2025-04-12 at 13 25 11" src="https://github.com/user-attachments/assets/327a0865-d79a-4d62-bb56-e3276680a715" />

NOTE: The problematic message was published by a logger that wasn't used anywhere else. Therefore, the logger was removed as well as the `log-path` command-line optiion related to it. 

Although, the issue with Sublime is fixed, I'm not really sure if that removal is acceptable and would appreciate any feedback.

---

Thank you for review and constructive feedback! 🍰 